### PR TITLE
docs: update README with usage and branding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
 # DebuffTracker
+
+DebuffTracker is a browser-based tool for tracking personal debuffs—uncomfortable states, symptoms, or habits—and routine tasks. The interface carries the **航·序AI** branding, which appears throughout the UI to represent the project's design identity.
+
+## Setup
+
+1. Clone this repository.
+2. No build step is required. Simply open `main.html` in any modern browser.
+
+## Usage
+
+- Use the “记录状态 (Debuff)” section to log new status entries.
+- Provide duration, intensity, and optional notes for each entry.
+- Manage recurring routines via the routine manager.
+- Export or import your data using the buttons at the bottom of the page.
+- Apply custom CSS through the settings interface for a personalized look.
+
+## Notes
+
+All data is stored locally in your browser’s `localStorage`. Use the export/import features to back up or transfer your records.
+


### PR DESCRIPTION
## Summary
- describe DebuffTracker purpose and 航·序AI branding
- add setup instructions for opening `main.html`
- outline basic usage for logging and data management

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689acdbb86c8832cb6df2eb01dd3df98