### PR TITLE
feat: add speech recognition and offline background

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,0 +1,119 @@
+// Background, speech recognition and offline logging
+(function(){
+  // --- Three.js Fluid Background ---
+  const canvas = document.getElementById('bg-canvas');
+  if (canvas && window.THREE) {
+    const renderer = new THREE.WebGLRenderer({canvas, alpha: true});
+    renderer.setSize(window.innerWidth, window.innerHeight);
+    const scene = new THREE.Scene();
+    const camera = new THREE.Camera();
+    const uniforms = {
+      uTime: { value: 0 },
+      uResolution: { value: new THREE.Vector2(window.innerWidth, window.innerHeight) }
+    };
+    const geometry = new THREE.PlaneGeometry(2, 2);
+    const material = new THREE.ShaderMaterial({
+      uniforms,
+      fragmentShader: `
+        uniform float uTime;
+        uniform vec2 uResolution;
+        float random(vec2 st){return fract(sin(dot(st.xy,vec2(12.9898,78.233)))*43758.5453123);} 
+        float noise(vec2 st){vec2 i=floor(st);vec2 f=fract(st);float a=random(i);float b=random(i+vec2(1.0,0.0));float c=random(i+vec2(0.0,1.0));float d=random(i+vec2(1.0,1.0));vec2 u=f*f*(3.0-2.0*f);return mix(a,b,u.x)+(c-a)*u.y*(1.0-u.x)+(d-b)*u.x*u.y;} 
+        void main(){
+          vec2 st=gl_FragCoord.xy/uResolution.xy*3.0;
+          float n=noise(st+uTime*0.1);
+          gl_FragColor=vec4(vec3(0.2,0.3,0.5)+0.3*vec3(n,n*0.5,n*0.8),1.0);
+        }
+      `
+    });
+    scene.add(new THREE.Mesh(geometry, material));
+    function animate(){
+      requestAnimationFrame(animate);
+      uniforms.uTime.value += 0.05;
+      renderer.render(scene, camera);
+    }
+    animate();
+    window.addEventListener('resize', ()=>{
+      renderer.setSize(window.innerWidth, window.innerHeight);
+      uniforms.uResolution.value.set(window.innerWidth, window.innerHeight);
+    });
+  }
+
+  // --- Speech Recognition & Emotion Colors ---
+  const speechBtn = document.getElementById('speech-btn');
+  const speechOutput = document.getElementById('speech-output');
+  let recognition;
+  if ('webkitSpeechRecognition' in window || 'SpeechRecognition' in window) {
+    const SR = window.SpeechRecognition || window.webkitSpeechRecognition;
+    recognition = new SR();
+    recognition.lang = 'zh-CN';
+    recognition.interimResults = false;
+    recognition.onresult = (e)=>{
+      const text = e.results[0][0].transcript;
+      const emotions = classifyText(text);
+      speechOutput.textContent = `${text} ` + JSON.stringify(emotions);
+      updateEmotionColors(emotions);
+      addLog({ text, emotions });
+    };
+    speechBtn && speechBtn.addEventListener('click', ()=> recognition.start());
+  } else {
+    if (speechBtn) speechBtn.style.display = 'none';
+  }
+
+  function classifyText(text) {
+    const result = { positive: 0.33, neutral: 0.34, negative: 0.33 };
+    const posWords = ['开心','快乐','好','棒','喜欢'];
+    const negWords = ['难过','不好','讨厌','生气','糟糕'];
+    let pos=0, neg=0;
+    posWords.forEach(w=>{ if(text.includes(w)) pos++; });
+    negWords.forEach(w=>{ if(text.includes(w)) neg++; });
+    if (pos+neg > 0) {
+      const total = pos+neg;
+      result.positive = pos/total;
+      result.negative = neg/total;
+      result.neutral = 1 - result.positive - result.negative;
+    }
+    return result;
+  }
+
+  const EMOTION_COLORS = {
+    positive: [140, 80, 60],
+    neutral: [210, 60, 60],
+    negative: [0, 80, 60]
+  };
+
+  function updateEmotionColors(weights) {
+    let h=0,s=0,l=0,total=0;
+    for (const k in weights) {
+      const w = weights[k];
+      const c = EMOTION_COLORS[k];
+      if (!c) continue;
+      h += c[0]*w; s += c[1]*w; l += c[2]*w; total += w;
+    }
+    if (total === 0) return;
+    const start = `hsl(${h/total}, ${s/total}%, ${l/total}%)`;
+    const end = `hsl(${(h/total + 40.0)%360}, ${s/total}%, ${Math.min(100, l/total + 10)}%)`;
+    document.documentElement.style.setProperty('--bg-start', start);
+    document.documentElement.style.setProperty('--bg-end', end);
+  }
+
+  // --- IndexedDB Logging ---
+  let db;
+  const req = indexedDB.open('debuff-logs', 1);
+  req.onupgradeneeded = e => {
+    e.target.result.createObjectStore('logs', { autoIncrement: true });
+  };
+  req.onsuccess = e => {
+    db = e.target.result;
+  };
+  function addLog(entry){
+    if (!db) return;
+    const tx = db.transaction('logs', 'readwrite');
+    tx.objectStore('logs').add({ ...entry, timestamp: Date.now() });
+  }
+
+  // --- Service Worker Registration ---
+  if ('serviceWorker' in navigator) {
+    navigator.serviceWorker.register('sw.js').catch(console.error);
+  }
+})();

--- a/main.html
+++ b/main.html
@@ -9,6 +9,7 @@
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+SC:wght@300;400;500;700&display=swap" rel="stylesheet">
 <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/three@0.161.0/build/three.min.js"></script>
 
 <style id="default-styles">
     /* Define CSS Variables */
@@ -51,6 +52,15 @@ body.light {
         opacity: 0; /* Start hidden for fade-in */
         animation: fadeInAnimation ease 0.6s forwards;
         animation-delay: 0.1s;
+    }
+
+    #bg-canvas {
+        position: fixed;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        z-index: -1;
     }
 
     @keyframes flowingGradient {
@@ -367,11 +377,16 @@ body.light {
 </style>
 </head>
 <body class="min-h-screen">
+    <canvas id="bg-canvas"></canvas>
     <div class="liquid-container">
         <header class="flex justify-between items-center">
             <h1>航·序AI</h1>
-            <button id="theme-toggle" class="btn-liquid-secondary"><i class="fas fa-adjust"></i></button>
+            <div class="flex gap-2">
+                <button id="speech-btn" class="btn-liquid-secondary"><i class="fas fa-microphone"></i></button>
+                <button id="theme-toggle" class="btn-liquid-secondary"><i class="fas fa-adjust"></i></button>
+            </div>
         </header>
+        <div id="speech-output" class="text-sm mt-2"></div>
 
 <main class="space-y-8">
         <section id="kanban-board" class="glass-section">
@@ -1196,5 +1211,6 @@ body.light {
         // --- END JS ---
     });
 </script>
+<script src="app.js"></script>
 </body>
 </html>

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,18 @@
+const CACHE_NAME = 'debuff-cache-v1';
+const ASSETS = [
+  './',
+  './main.html',
+  './app.js'
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(ASSETS))
+  );
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request).then(resp => resp || fetch(event.request))
+  );
+});


### PR DESCRIPTION
## Summary
- render animated fluid background with three.js canvas
- integrate Web Speech API classification and emotion-based color shifting
- add service worker cache and IndexedDB log persistence

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689ad016e568832c81ccea14983ba3b0